### PR TITLE
Use LayoutManager to get the rect of the line selected in the textView.

### DIFF
--- a/Backlight/AAABacklight.m
+++ b/Backlight/AAABacklight.m
@@ -240,11 +240,10 @@ static AAABacklight *sharedPlugin;
 
     if (selectedRange.length != 0 && ![self settingForKey:kAAAAlwaysEnableLineBacklight]) return;
 
-    NSRect rectInScreen = [textView firstRectForCharacterRange:selectedRange actualRange:NULL];
-    NSRect rectInWindow = [textView.window convertRectFromScreen:rectInScreen];
-    NSRect rectInView   = [textView convertRect:rectInWindow fromView:nil];
+    NSRange glyphRange = [textView.layoutManager glyphRangeForCharacterRange:selectedRange actualCharacterRange:NULL];
+    NSRect glyphRect = [textView.layoutManager boundingRectForGlyphRange:glyphRange inTextContainer:textView.textContainer];
 
-    NSRect backlightRect = rectInView;
+    NSRect backlightRect = glyphRect;
     backlightRect.origin.x = 0;
     backlightRect.size.width = textView.bounds.size.width;
     self.currentBacklightView.frame = backlightRect;


### PR DESCRIPTION
I noticed an issue that after moved the current line to the top(or bottom) of the editor(not the beginning/end of the file), when trying to move up(or down) again to get next line, the backlight disappears.
Also, in the situation that the current line's length is longer than the screen's width(say current line has 200 characters and the editor's width is 120), when moving the cursor to the head/end of that line, the issue happens.

I added some log to the method `moveBacklightInTextView:`, and found that when the issue happens, the rectInScreen variable whose value was got from `[textView firstRectForCharacterRange:selectedRange actualRange:NULL];` was (0, 0, 0, 0).
I don't know what caused the issue(Though from the document, `firstRectForCharacterRange: actualRange:` is marked as "Deprecated in OS X v10.6."), but think maybe we can retrieve the selected line's rect by NSTextView's NSLayoutManager.

My test environment is OS X 10.10.1 + Xcode 6.1.1
