### PR TITLE
Fix bug: the on/off state of "Line backlight" item is not synced.

### DIFF
--- a/Backlight/AAABacklight.m
+++ b/Backlight/AAABacklight.m
@@ -160,6 +160,7 @@ static AAABacklight *sharedPlugin;
 - (void)toggleEnableLineBacklight:(NSMenuItem *)sender
 {
     [self toggleSettingForKey:kAAAEnableLineBacklight];
+    sender.state = [self stateForSettingForKey:kAAAEnableLineBacklight];
     [self adjustBacklight];
 }
 


### PR DESCRIPTION
I think you forget to sync the state of menu item "Line backlight".
It causes the check mark of "Line backlight" item is either always there or always not there if you don't restart Xcode.
