### PR TITLE
Underneath mode

### DIFF
--- a/Backlight/AAABacklight.m
+++ b/Backlight/AAABacklight.m
@@ -265,6 +265,7 @@ static AAABacklight *sharedPlugin;
     if (!panel.color && [[NSApp keyWindow] firstResponder] != self.textView) return;
 
     self.currentBacklightView.backlightColor = panel.color;
+    self.backlightColor = panel.color;
 
     NSData *colorData = [NSArchiver archivedDataWithRootObject:panel.color];
     [[NSUserDefaults standardUserDefaults] setObject:colorData forKey:kAAALineBacklightColor];

--- a/Backlight/AAABacklight.m
+++ b/Backlight/AAABacklight.m
@@ -242,8 +242,6 @@ static AAABacklight *sharedPlugin;
     [self.currentBacklightView setNeedsDisplay:YES];
 }
 
-#pragma mark - Actions
-
 - (void)showColorPanel
 {
 	NSColorPanel *panel = [NSColorPanel sharedColorPanel];

--- a/Backlight/AAABacklight.m
+++ b/Backlight/AAABacklight.m
@@ -266,6 +266,17 @@ static AAABacklight *sharedPlugin;
 
     self.currentBacklightView.backlightColor = panel.color;
     self.backlightColor = panel.color;
+    if (self.textView) {
+        if ([self.textView.layoutManager temporaryAttribute:NSBackgroundColorAttributeName
+                                           atCharacterIndex:self.currentLineRange.location
+                                             effectiveRange:NULL]) {
+            [self.textView.layoutManager removeTemporaryAttribute:NSBackgroundColorAttributeName
+                                                forCharacterRange:self.currentLineRange];
+            [self.textView.layoutManager addTemporaryAttribute:NSBackgroundColorAttributeName
+                                                         value:self.backlightColor
+                                             forCharacterRange:self.currentLineRange];
+        }
+    }
 
     NSData *colorData = [NSArchiver archivedDataWithRootObject:panel.color];
     [[NSUserDefaults standardUserDefaults] setObject:colorData forKey:kAAALineBacklightColor];


### PR DESCRIPTION
First of all, this is really **NOT** a big deal :)
The "Underneath mode" is just another way to add the backlight to the current line, which is using NSLayoutManager's `addTemporaryAttribute:value:forCharacterRange: ` method to add a background color to the current line.

The effect is just a little different though. You can check the attached image for the comparison.
The upper one is using the original way(a overlaid view), while the under one is using the so-called "underneath mode". Both backlight colors are using 0.2 alpha value.

*Please note the red parts. The color composition is a little different according to the position of the parts with alpha channel.*
![comparison](https://cloud.githubusercontent.com/assets/788863/5342350/94a3ff5e-7f40-11e4-818b-c92b4f0c806e.png)


I think the pros and cons of the "Underneath mode" are:
* Pros
  - Using `NSLayoutManager`'s method to render the background color is simpler and maybe faster than adding a subview to the editor's textview.
  - The color composition is a little clearer especially when using a dark theme with the backlight color of a little bigger alpha value(like > 0.2).
* Cons
  - We'll lose the "Stroke" and "Round corner" effect because what `NSLayoutManager` can do is just change the background color. (That's why I add this mode as another option of the original one. Let the user choose the appropriate one)