### PR TITLE
Fix #27

### DIFF
--- a/Backlight/AAABacklight.m
+++ b/Backlight/AAABacklight.m
@@ -141,6 +141,8 @@ static AAABacklight *sharedPlugin;
                                                  name:NSWindowDidResizeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(backlightNotification:)
                                                  name:NSWindowDidBecomeKeyNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(endBacklightNotification:)
+                                                 name:NSTextDidEndEditingNotification object:nil];
 
     return self;
 }
@@ -287,6 +289,24 @@ static AAABacklight *sharedPlugin;
     if (![firstResponder isKindOfClass:NSClassFromString(@"DVTSourceTextView")]) return;
 
     [self updateBacklightViewWithTextView:firstResponder];
+}
+
+/**
+ * Respond to NSTextDidEndEditingNotification to remove the highlighted background color.
+ */
+- (void)endBacklightNotification:(NSNotification *)notification {
+    id firstResponder = [[NSApp keyWindow] firstResponder];
+    if (![firstResponder isKindOfClass:NSClassFromString(@"DVTSourceTextView")]) return;
+
+    if (self.textView != nil &&
+        self.textView == firstResponder &&
+        self.currentMode == AAABacklightModeUnderneath &&
+        [self.textView.layoutManager temporaryAttribute:NSBackgroundColorAttributeName
+                                       atCharacterIndex:self.currentLineRange.location
+                                         effectiveRange:NULL]) {
+            [self.textView.layoutManager removeTemporaryAttribute:NSBackgroundColorAttributeName
+                                                forCharacterRange:self.currentLineRange];
+        }
 }
 
 - (void)colorPanelWillClose:(NSNotification *)notification


### PR DESCRIPTION
Remove the highlighted line when editor lost focus. The behaviour is the same as Overlay mode.

#### What caused the issue

When using Underneath mode, the current line is highlighted by the **current** editor's layout manager. The editor is not aware when the focus changed to somewhere else, so the highlighted line remains there.

#### Why not happen in Overlay mode

In Overlay mode, when focus changed to another editor, the NSWindowDidBecomeKeyNotification will fire in the new editor. Then in `moveBacklightInTextView:` method, `[self.currentBacklightView removeFromSuperview];` will execute and the old highlighted line will be removed.