### PR TITLE
Underneath mode: Remove the old highlight before switching textView.

### DIFF
--- a/Backlight/AAABacklight.m
+++ b/Backlight/AAABacklight.m
@@ -141,8 +141,6 @@ static AAABacklight *sharedPlugin;
                                                  name:NSWindowDidResizeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(backlightNotification:)
                                                  name:NSWindowDidBecomeKeyNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(endBacklightNotification:)
-                                                 name:NSTextDidEndEditingNotification object:nil];
 
     return self;
 }
@@ -326,6 +324,17 @@ static AAABacklight *sharedPlugin;
 
 - (void)updateBacklightViewWithTextView:(NSTextView *)textView
 {
+    // Before changing the textView's instance, remove the old one's highlight.
+    if (self.textView != textView &&
+        self.currentMode == AAABacklightModeUnderneath &&
+        [self.textView.layoutManager temporaryAttribute:NSBackgroundColorAttributeName
+                                       atCharacterIndex:self.currentLineRange.location
+                                         effectiveRange:NULL])
+    {
+        [self.textView.layoutManager removeTemporaryAttribute:NSBackgroundColorAttributeName
+                                            forCharacterRange:self.currentLineRange];
+    }
+
     self.textView = textView;
 
     [self adjustBacklight];

--- a/Backlight/AAABacklight.m
+++ b/Backlight/AAABacklight.m
@@ -307,7 +307,8 @@ static AAABacklight *sharedPlugin;
 - (void)updateBacklightViewWithTextView:(NSTextView *)textView
 {
     // Before changing the textView's instance, remove the old one's highlight.
-    if (self.textView != textView &&
+    if (self.textView != nil &&
+        self.textView != textView &&
         self.currentMode == AAABacklightModeUnderneath &&
         [self.textView.layoutManager temporaryAttribute:NSBackgroundColorAttributeName
                                        atCharacterIndex:self.currentLineRange.location

--- a/Backlight/AAABacklight.m
+++ b/Backlight/AAABacklight.m
@@ -289,24 +289,6 @@ static AAABacklight *sharedPlugin;
     [self updateBacklightViewWithTextView:firstResponder];
 }
 
-/**
- * Respond to NSTextDidEndEditingNotification to remove the highlighted background color.
- */
-- (void)endBacklightNotification:(NSNotification *)notification {
-    id firstResponder = [[NSApp keyWindow] firstResponder];
-    if (![firstResponder isKindOfClass:NSClassFromString(@"DVTSourceTextView")]) return;
-
-    if (self.textView != nil &&
-        self.textView == firstResponder &&
-        self.currentMode == AAABacklightModeUnderneath &&
-        [self.textView.layoutManager temporaryAttribute:NSBackgroundColorAttributeName
-                                       atCharacterIndex:self.currentLineRange.location
-                                         effectiveRange:NULL]) {
-            [self.textView.layoutManager removeTemporaryAttribute:NSBackgroundColorAttributeName
-                                                forCharacterRange:self.currentLineRange];
-        }
-}
-
 - (void)colorPanelWillClose:(NSNotification *)notification
 {
     NSColorPanel *panel = [NSColorPanel sharedColorPanel];


### PR DESCRIPTION
To  make sure the old one doesn't remain there.

In the previous fix of #27 , I tried to observe the NSTextDidEndEditingNotification to check if the old highlight should be removed. But obviously it's not enough: #35 

So perform the removing the old highlight by the timing of switching textView. The current action should be the same as Overlay mode.