### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Backlight for XCode
+Backlight for Xcode
 =========
 
 Highlights the current editing line in Xcode
@@ -7,8 +7,8 @@ Highlights the current editing line in Xcode
 
 Installing:
 
-1. Build with XCode
-2. Restart XCode
+1. Build with Xcode
+2. Restart Xcode
 
 Usage:
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Would be a stretch to rename the Github project..
